### PR TITLE
tiny tweak for better type safety

### DIFF
--- a/pkgs/core/core.ts
+++ b/pkgs/core/core.ts
@@ -197,7 +197,7 @@ export function rval(base?: Val<any, any>): RValInstance {
 
 const globalProp = "defaultRValInstance" 
 const defaultPreProcessor = value => value
-export const defaultInstance = global[globalProp] = (() => {
+export const defaultInstance: RValInstance = global[globalProp] = (() => {
   const globalInstance = global[globalProp]
   if (globalInstance) {
     console.warn("Note: RVal is included in this project twice") // TODO: which is fine, unless this one is used..


### PR DESCRIPTION
This tweak improves the type safety on the exported api. 

There is one more trivial thing that I wanted to mention, not related to the above issue. 
In the core.ts file there is an exported interface called Observable. I believe that this  interface which is also used in the react.ts file for example should be better to have a different name or to be private because in the future it might lead to misconceptions. The rxjs Observable and the native js Observable(in the future) have a different shape than the one in this library. So, a name like Rval instead of Observable would be more intuitive. Also I would change ObservableValue => Subject and ObservableAdministration => SubjectAdministration. Traditionally, Subjects are "multicast". That means that a subject can have multiple listeners and state like your implementation. On the other hand an Observable is always unicast. 

Nevertheless, they are just names.
